### PR TITLE
Add text-muted note for supported image formats

### DIFF
--- a/src/components/Product/FormTable.tsx
+++ b/src/components/Product/FormTable.tsx
@@ -180,6 +180,9 @@ const PictureFormControl = ({
         accept="image/*"
         isInvalid={field.isRequired && !picture}
       />
+      <Form.Text className="text-muted">
+        僅支援圖片格式 (png, jpg, jpeg)
+      </Form.Text>
       {picture && (
         <div className="mt-2">
           <Form.Label>預覽</Form.Label>


### PR DESCRIPTION
This pull request adds a text-muted note in the PictureFormControl component to inform users that only certain image formats (png, jpg, jpeg) are supported.