### PR TITLE
Fix prettier

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,12 +16,12 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
   },
   "include": ["src", "vite.config.ts", ".eslintrc.cjs"],
   "references": [
     {
-      "path": "./tsconfig.node.json"
-    }
-  ]
+      "path": "./tsconfig.node.json",
+    },
+  ],
 }


### PR DESCRIPTION
This pull request fixes the prettier configuration in the project. The `noFallthroughCasesInSwitch` option was missing a comma at the end, causing a syntax error. This PR adds the missing comma to the configuration file.