### PR TITLE
Add API_HOST extraction from GitHub Secrets and update token refresh time

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,6 +35,8 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Extract API_HOST from GitHub Secrets
+        run: echo "VITE_API_HOST=${{ secrets.VITE_API_HOST }}" > .env
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -78,7 +78,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       }
 
       // If the token will expire within 5 minutes, refresh the token
-      if (timeDifference <= 29) {
+      if (timeDifference <= 5) {
         // Call refresh API
         const response = await refresh();
         if (response.status === 200) {


### PR DESCRIPTION
This pull request adds a step to extract the API_HOST from GitHub Secrets and updates the token refresh time to 5 minutes instead of 29 minutes.