### PR TITLE
Fix date and number field handling in product create and edit forms

### DIFF
--- a/src/components/Product/Create.tsx
+++ b/src/components/Product/Create.tsx
@@ -100,6 +100,9 @@ export const Create = () => {
   const handleSubmit = () => {
     // 因應日期格式，統一在送出前轉換成 yyyy/MM/dd
     const parsedAttributes = attributes.map((attribute) => {
+      const currentFieldDetail = fields!.find(
+        (field) => field.id === attribute.fieldId
+      )!;
       if (/^\d{4}-\d{2}-\d{2}$/.test(attribute.value as string)) {
         return {
           ...attribute,
@@ -107,7 +110,10 @@ export const Create = () => {
         };
       }
       // 純數字的話轉成數字
-      else if (/^[-\d]+$/.test(attribute.value as string)) {
+      else if (
+        /^[-\d]+$/.test(attribute.value as string) &&
+        currentFieldDetail.dataType === SeriesFieldDataType.number
+      ) {
         return {
           ...attribute,
           value: parseFloat(attribute.value as string),

--- a/src/components/Product/Create.tsx
+++ b/src/components/Product/Create.tsx
@@ -111,7 +111,7 @@ export const Create = () => {
       }
       // 純數字的話轉成數字
       else if (
-        /^[-\d]+$/.test(attribute.value as string) &&
+        /^[-\d.]+$/.test(attribute.value as string) &&
         currentFieldDetail.dataType === SeriesFieldDataType.number
       ) {
         return {

--- a/src/components/Product/Edit.tsx
+++ b/src/components/Product/Edit.tsx
@@ -164,7 +164,7 @@ export const Edit = () => {
       }
       // 純數字的話轉成數字
       else if (
-        /^[-\d]+$/.test(attribute.value as string) &&
+        /^[-\d.]+$/.test(attribute.value as string) &&
         currentFieldDetail.dataType === SeriesFieldDataType.number
       ) {
         return {

--- a/src/components/Product/Edit.tsx
+++ b/src/components/Product/Edit.tsx
@@ -152,7 +152,10 @@ export const Edit = () => {
 
   const handleSubmit = () => {
     // 因應日期格式，統一在送出前轉換成 yyyy/MM/dd
-    const parsedAttributes = editAttributes.map((attribute) => {
+    const parsedAttributes = attributes.map((attribute) => {
+      const currentFieldDetail = fields!.find(
+        (field) => field.id === attribute.fieldId
+      )!;
       if (/^\d{4}-\d{2}-\d{2}$/.test(attribute.value as string)) {
         return {
           ...attribute,
@@ -160,7 +163,10 @@ export const Edit = () => {
         };
       }
       // 純數字的話轉成數字
-      else if (/^[-\d]+$/.test(attribute.value as string)) {
+      else if (
+        /^[-\d]+$/.test(attribute.value as string) &&
+        currentFieldDetail.dataType === SeriesFieldDataType.number
+      ) {
         return {
           ...attribute,
           value: parseFloat(attribute.value as string),


### PR DESCRIPTION
This pull request fixes the handling of date and number fields in the product create and edit forms. It ensures that dates are converted to the format "yyyy/MM/dd" before submission and that pure numbers are converted to the appropriate data type.