### PR TITLE
feat(product-create): replace redirect alert with modal dialog on success

### DIFF
--- a/src/components/Product/Create.tsx
+++ b/src/components/Product/Create.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Col, Form, Row, Stack } from "react-bootstrap";
+import { Alert, Button, Col, Form, Modal, Row, Stack } from "react-bootstrap";
 import FormTable from "./FormTable";
 import {
   SeriesDetailResponse,
@@ -48,6 +48,7 @@ export const Create = () => {
   const [selectedSeries, setSelectedSeries] = useState<number>(0);
   const [attributes, setAttributes] = useState<ProductAttributePayload[]>([]);
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [newProductId, setNewProductId] = useState<number | null>(null);
   const [
     { data: seriesDetailResponse, loading: seriesDetailLoading },
     fetchSeriesDetail,
@@ -116,14 +117,8 @@ export const Create = () => {
     })
       .then((response) => {
         const newId = response.data.data?.[0]?.id;
+        setNewProductId(newId ?? null);
         setSaveSuccess(true);
-        setTimeout(() => {
-          if (newId) {
-            navigate(`/products/${newId}/edit`);
-          } else {
-            navigate("/products");
-          }
-        }, 1000);
       })
       .catch((e) =>
         alert(
@@ -140,11 +135,35 @@ export const Create = () => {
       <Backdrop show={pageLoading}>
         <RingLoader color="#36d7b7" />
       </Backdrop>
-      {saveSuccess && (
-        <Alert variant="success" className="mb-2">
-          儲存成功！正在跳轉到編輯頁面...
-        </Alert>
-      )}
+      <Modal show={saveSuccess} centered>
+        <Modal.Header>
+          <Modal.Title>新增成功</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>產品已成功新增，是否前往編輯頁面？</Modal.Body>
+        <Modal.Footer>
+          <Button
+            variant="primary"
+            onClick={() => {
+              if (newProductId) {
+                navigate(`/products/${newProductId}/edit`);
+              } else {
+                navigate("/products");
+              }
+            }}
+          >
+            前往編輯
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              setSaveSuccess(false);
+              navigate("/products");
+            }}
+          >
+            返回列表
+          </Button>
+        </Modal.Footer>
+      </Modal>
       <Row className="mb-2">
         <Col>
           <Form.Select onChange={(e) => handleSelect(e)}>


### PR DESCRIPTION
## Summary
- 將新增產品成功後的 inline Alert 提示改為浮動 Modal 對話框
- 移除原本 1 秒後自動跳轉至編輯頁的行為
- 使用者可自行選擇「前往編輯」或「返回列表」

## Test plan
- [ ] 新增產品後，確認出現浮動 Modal
- [ ] 點擊「前往編輯」確認跳轉至編輯頁面
- [ ] 點擊「返回列表」確認跳轉至產品列表

🤖 Generated with [Claude Code](https://claude.com/claude-code)