### PR TITLE
fix(product): return to correct series after creating product

### DIFF
--- a/src/components/Product/Create.tsx
+++ b/src/components/Product/Create.tsx
@@ -157,7 +157,7 @@ export const Create = () => {
             variant="secondary"
             onClick={() => {
               setSaveSuccess(false);
-              navigate("/products");
+              navigate(`/products?seriesId=${selectedSeries}`);
             }}
           >
             返回列表

--- a/src/components/Product/Search.tsx
+++ b/src/components/Product/Search.tsx
@@ -536,6 +536,12 @@ const Bar = ({
   }, [series, selectedSeries, page, refreshKey, limit, sortState, status]);
 
   useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const seriesIdFromUrl = params.get("seriesId");
+    if (seriesIdFromUrl) {
+      setSelectedSeries(parseInt(seriesIdFromUrl));
+      return;
+    }
     const { selectedSeries, limit, page, searchFields, status } = restore();
     if (selectedSeries) setSelectedSeries(selectedSeries);
     if (limit && pageSizes.includes(limit)) setLimit(limit);


### PR DESCRIPTION
## Summary

- 新增產品儲存後按「返回列表」，現在會正確導回該產品所屬的系列頁面
- 根本原因：`Search.tsx` 使用 `localStorage` 記錄上次搜尋的 seriesId，但 localStorage 是跨 session 持久化的，Jenny 電腦上存的是她**上次搜尋**的系列，不是她正在新增產品的系列
- 修法：`Create.tsx` 返回列表時帶 `?seriesId=` query param；`Search.tsx` 優先讀取 URL param，略過 localStorage

## Changes

- `Create.tsx`: `navigate("/products")` → `navigate(\`/products?seriesId=${selectedSeries}\`)`
- `Search.tsx`: `useEffect([location])` 優先檢查 `location.search` 的 `seriesId` param

## Test plan

- [ ] 在系列 A 的產品列表搜尋（讓 localStorage 存入 seriesId=A）
- [ ] 切換到系列「01-2」，新增產品
- [ ] 儲存後按「返回列表」→ 確認回到「01-2」系列，而非系列 A
- [ ] 一般從列表頁進出（不帶 query param）確認 localStorage restore 行為不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)